### PR TITLE
Add LighterPack research notes and LLM modernization proposal

### DIFF
--- a/notes/lighterpack-llm-modernization.md
+++ b/notes/lighterpack-llm-modernization.md
@@ -1,0 +1,42 @@
+# LighterPack LLM Modernization Proposal
+
+## Goals
+- Build a modern service inspired by LighterPack that helps users create, analyze, and share gear lists.
+- Use LLMs to reduce manual data entry, improve organization, and provide decision support.
+
+## Core LLM Features
+1. **Smart item entry**
+   - Paste text, receipts, or product links and auto-extract item name, weight, category, and price.
+   - Normalize units and flag missing or suspicious weights.
+2. **List refinement**
+   - Auto-categorize items (shelter, sleep, cook, etc.) and suggest reorganizations.
+   - Detect duplicates or redundant items across categories.
+3. **What-if planning**
+   - Generate alternate pack configurations for different trip styles and weather.
+   - Explain tradeoffs (weight vs. warmth, durability vs. cost) in plain language.
+4. **Personalized recommendations**
+   - Suggest lighter alternatives or multi-use items based on user preferences.
+   - Respect constraints such as budget, base weight targets, and comfort priorities.
+5. **Sharing & collaboration**
+   - Summarize lists for sharing (e.g., “3-season weekend pack summary”).
+   - Provide “diff” summaries when a shared list changes.
+
+## Data Model Ideas
+- **Item**: name, description, weight, unit, category, cost, consumable, worn, quantity, URL, image.
+- **Pack**: name, trip details, location, season, target base weight, notes.
+- **Insight**: LLM-generated summaries, suggestions, and tradeoff notes.
+
+## UX/UI Modernization
+- Clean, mobile-first interface with quick add and inline editing.
+- Visual base weight breakdown with drill-down category charts.
+- Inline “LLM helper” panel for summaries and suggestions.
+
+## MVP Scope
+- Import lists from CSV and plain text.
+- LLM-assisted item parsing and category suggestion.
+- Base weight calculations and shareable public links.
+
+## Next Steps
+- Validate the feature list with target users (ultralight hikers).
+- Decide LLM provider and cost controls (prompt caching, usage caps).
+- Create a data ingestion pipeline for item parsing.

--- a/notes/lighterpack-research.md
+++ b/notes/lighterpack-research.md
@@ -1,0 +1,11 @@
+# LighterPack (web research)
+
+Source: https://lighterpack.com/ (via https://r.jina.ai/http://lighterpack.com/)
+
+Key statements from the site:
+
+- "LighterPack helps you track the gear you bring on adventures."
+- Getting started flow highlights three steps: "Enter your packing lists", "Visualize your pack weights", and "Share your lists with others".
+- The site credits: "Site by Galen Maly and friends" and lists a contact email.
+
+Captured on 2025-02-07.


### PR DESCRIPTION
### Motivation
- Capture a concise local summary of the LighterPack homepage for project research and reference.
- Propose a concrete LLM-driven modernization plan to guide implementation and scope decisions for a LighterPack-inspired service.

### Description
- Add `notes/lighterpack-research.md` which summarizes the LighterPack homepage, core getting-started flow, site credits, and capture date.
- Add `notes/lighterpack-llm-modernization.md` which outlines goals, core LLM features (smart item entry, list refinement, what-if planning, personalized recommendations, sharing), data model ideas, UX/UI modernization notes, MVP scope, and next steps.

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870a6c726083328eb251e8177b32e5)