### PR TITLE
feat: ギアリストからドラッグ&ドロップでパッキングリストにアイテム追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",
@@ -744,6 +745,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",

--- a/frontend/src/components/gear-sidebar.tsx
+++ b/frontend/src/components/gear-sidebar.tsx
@@ -1,0 +1,109 @@
+import { useQuery } from '@tanstack/react-query'
+import { useDraggable } from '@dnd-kit/core'
+import { GripVerticalIcon, PackageIcon } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { api } from '@/lib/api'
+import { categoryLabel, formatWeight, kindLabel } from '@/lib/format'
+import type { GearListItem, Unit } from '@/lib/types'
+import { useState } from 'react'
+
+function DraggableGearItem({ item, unit }: { item: GearListItem; unit: Unit }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `gear-${item.id}`,
+    data: { gearItem: item },
+  })
+
+  const style = transform
+    ? { transform: `translate(${transform.x}px, ${transform.y}px)` }
+    : undefined
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-2 rounded-md border bg-card p-2 text-sm ${
+        isDragging ? 'opacity-50 shadow-lg' : 'hover:bg-accent/50'
+      }`}
+    >
+      <button
+        type="button"
+        className="shrink-0 cursor-grab touch-none text-muted-foreground hover:text-foreground"
+        {...listeners}
+        {...attributes}
+      >
+        <GripVerticalIcon className="size-4" />
+      </button>
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium">{item.name}</div>
+        <div className="flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+          <Badge variant="outline" className="text-xs">
+            {categoryLabel(item.category)}
+          </Badge>
+          <Badge variant="secondary" className="text-xs">
+            {kindLabel(item.kind)}
+          </Badge>
+          <span>{formatWeight(item.weight_grams, unit)}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type GearSidebarProps = {
+  unit: Unit
+  currentListId: string
+}
+
+export function GearSidebar({ unit, currentListId }: GearSidebarProps) {
+  const [search, setSearch] = useState('')
+
+  const gearQuery = useQuery({
+    queryKey: ['gear-items'],
+    queryFn: () => api.getGearItems(),
+  })
+
+  if (gearQuery.isLoading) return <p className="p-4 text-sm text-muted-foreground">読み込み中...</p>
+  if (gearQuery.isError) return <p className="p-4 text-sm text-destructive">ギアの取得に失敗しました。</p>
+
+  const allItems = gearQuery.data ?? []
+  // Filter out items that belong to the current list
+  const availableItems = allItems.filter((item) => item.list_id !== currentListId)
+
+  const filteredItems = search.trim()
+    ? availableItems.filter(
+        (item) =>
+          item.name.toLowerCase().includes(search.toLowerCase()) ||
+          categoryLabel(item.category).includes(search)
+      )
+    : availableItems
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b p-3">
+        <PackageIcon className="size-4 shrink-0 text-muted-foreground" />
+        <h3 className="text-sm font-semibold">マイギア</h3>
+      </div>
+      <div className="p-3">
+        <Input
+          placeholder="ギアを検索..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="h-8 text-sm"
+        />
+      </div>
+      <div className="flex-1 space-y-1 overflow-y-auto px-3 pb-3">
+        {filteredItems.length === 0 ? (
+          <p className="py-4 text-center text-xs text-muted-foreground">
+            {availableItems.length === 0 ? 'ギアが登録されていません' : '該当するギアがありません'}
+          </p>
+        ) : (
+          filteredItems.map((item) => (
+            <DraggableGearItem key={item.id} item={item} unit={unit} />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
パッキングリスト詳細ページに左サイドバーのギアパネルを追加し、
@dnd-kit/coreを使用してドラッグ&ドロップでアイテムを追加できるようにした。

- GearSidebarコンポーネント: ギア一覧表示、検索フィルタ、ドラッグ可能なアイテム
- ListDetailPageにDndContext統合、ドロップゾーン、ドラッグオーバーレイ
- サイドバーの表示/非表示切り替えボタン

https://claude.ai/code/session_01C3UMnYBmWPgPPvDNPzxeae