### PR TITLE
Add packing list templates and clone-from-template flow

### DIFF
--- a/frontend/src/components/__tests__/list-create-form.test.tsx
+++ b/frontend/src/components/__tests__/list-create-form.test.tsx
@@ -8,12 +8,12 @@ describe('ListCreateForm', () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
 
-    render(<ListCreateForm isSubmitting={false} onSubmit={onSubmit} />)
+    render(<ListCreateForm isSubmitting={false} templates={[]} onSubmit={onSubmit} />)
 
     await user.type(screen.getByLabelText('Title'), 'Test list')
     await user.type(screen.getByLabelText('説明'), 'desc')
     await user.click(screen.getByRole('button', { name: 'リストを作成' }))
 
-    expect(onSubmit).toHaveBeenCalledWith({ title: 'Test list', description: 'desc' })
+    expect(onSubmit).toHaveBeenCalledWith({ title: 'Test list', description: 'desc', template_id: undefined })
   })
 })

--- a/frontend/src/components/list-create-form.tsx
+++ b/frontend/src/components/list-create-form.tsx
@@ -1,21 +1,33 @@
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
+import type { PackingList } from '@/lib/types'
 
 export type ListFormValue = {
   title: string
   description: string
+  template_id?: string
 }
 
 type Props = {
   isSubmitting: boolean
+  templates: PackingList[]
   onSubmit: (values: ListFormValue) => Promise<void>
 }
 
-export function ListCreateForm({ isSubmitting, onSubmit }: Props) {
+export function ListCreateForm({ isSubmitting, templates, onSubmit }: Props) {
+  const [templateId, setTemplateId] = useState<string | undefined>(undefined)
   const {
     register,
     handleSubmit,
@@ -26,12 +38,33 @@ export function ListCreateForm({ isSubmitting, onSubmit }: Props) {
   })
 
   const submit = async (values: ListFormValue) => {
-    await onSubmit({ title: values.title.trim(), description: values.description.trim() })
+    await onSubmit({
+      title: values.title.trim(),
+      description: values.description.trim(),
+      template_id: templateId,
+    })
     reset()
+    setTemplateId(undefined)
   }
 
   return (
     <form className="grid gap-4" onSubmit={handleSubmit(submit)}>
+      <div className="grid gap-2">
+        <Label htmlFor="template">テンプレート</Label>
+        <Select value={templateId ?? 'none'} onValueChange={(value) => setTemplateId(value === 'none' ? undefined : value)}>
+          <SelectTrigger id="template">
+            <SelectValue placeholder="テンプレートを選択（任意）" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">選択しない</SelectItem>
+            {templates.map((template) => (
+              <SelectItem key={template.id} value={template.id}>
+                {template.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
       <div className="grid gap-2">
         <Label htmlFor="title">Title</Label>
         <Input id="title" {...register('title', { required: true, maxLength: 100 })} placeholder="Northern Alps 2 days" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,6 +59,7 @@ const listPath = (listId: string, suffix = '') => `/api/v1/lists/${listId}${suff
 export type ListPayload = {
   title: string
   description: string
+  template_id?: string
 }
 
 export type ItemPayload = {
@@ -83,6 +84,8 @@ export const api = {
     request<PackingListDetail>(listPath(listId, `/items/${itemId}`), { method: 'DELETE' }),
   setUnit: (listId: string, unit: Unit) =>
     requestWithBody<PackingListDetail>(listPath(listId, '/unit'), 'PATCH', { unit }),
+  setTemplate: (listId: string, is_template: boolean) =>
+    requestWithBody<PackingListDetail>(listPath(listId, '/template'), 'PATCH', { is_template }),
   getShared: (token: string) => request<SharedPackingList>(`/api/v1/shared/${token}`),
   regenerateShareToken: (listId: string) =>
     request<PackingListDetail>(listPath(listId, '/share/regenerate'), { method: 'POST' }),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -52,6 +52,7 @@ export type PackingList = {
   unit: Unit
   share_token: string
   is_shared: boolean
+  is_template: boolean
   created_at: string
   updated_at: string
 }

--- a/frontend/src/pages/__tests__/lists-page.test.tsx
+++ b/frontend/src/pages/__tests__/lists-page.test.tsx
@@ -51,6 +51,7 @@ describe('ListsPage', () => {
       unit: 'g',
       share_token: '',
       is_shared: false,
+      is_template: false,
       created_at: '',
       updated_at: '',
     })
@@ -83,6 +84,7 @@ describe('ListsPage', () => {
         unit: 'g',
         share_token: '',
         is_shared: false,
+        is_template: false,
         created_at: '',
         updated_at: '',
       },

--- a/frontend/src/pages/list-detail-page.tsx
+++ b/frontend/src/pages/list-detail-page.tsx
@@ -107,6 +107,15 @@ export function ListDetailPage() {
     onError: (error) => toast.error(mutationErrorMessage(error, '単位の更新に失敗しました')),
   })
 
+  const setTemplateMutation = useMutation({
+    mutationFn: (isTemplate: boolean) => api.setTemplate(listId ?? '', isTemplate),
+    onSuccess: async (_, isTemplate) => {
+      await invalidateListQuery()
+      toast.success(isTemplate ? 'テンプレートとして保存しました' : 'テンプレート設定を解除しました')
+    },
+    onError: (error) => toast.error(mutationErrorMessage(error, 'テンプレート設定の更新に失敗しました')),
+  })
+
   const regenerateShareMutation = useMutation({
     mutationFn: () => api.regenerateShareToken(listId ?? ''),
     onSuccess: async () => {
@@ -156,6 +165,14 @@ export function ListDetailPage() {
               </SelectContent>
             </Select>
           </div>
+          <Button
+            variant="outline"
+            onClick={() => {
+              void setTemplateMutation.mutateAsync(!list.is_template)
+            }}
+          >
+            {list.is_template ? 'テンプレート解除' : 'テンプレートとして保存'}
+          </Button>
           <Button
             variant="outline"
             onClick={() => {

--- a/frontend/src/pages/lists-page.tsx
+++ b/frontend/src/pages/lists-page.tsx
@@ -62,6 +62,7 @@ export function ListsPage() {
   })
   const hasGearItems = Boolean(gearItemsQuery.data && gearItemsQuery.data.length > 0)
   const hasLists = Boolean(listQuery.data && listQuery.data.length > 0)
+  const templates = listQuery.data?.filter((list) => list.is_template) ?? []
 
   return (
     <div className="grid gap-6">
@@ -161,6 +162,7 @@ export function ListsPage() {
               </DialogHeader>
               <ListCreateForm
                 isSubmitting={createListMutation.isPending}
+                templates={templates}
                 onSubmit={async (values) => {
                   await createListMutation.mutateAsync(values)
                 }}

--- a/src/ul_packing/models.py
+++ b/src/ul_packing/models.py
@@ -42,6 +42,7 @@ class PackingList(Base):
     unit: Mapped[Unit] = mapped_column(Enum(Unit), default=Unit.G, nullable=False)
     share_token: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
     is_shared: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_template: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/ul_packing/schemas_api.py
+++ b/src/ul_packing/schemas_api.py
@@ -61,6 +61,7 @@ class PackingListListItemOut(BaseModel):
     unit: Unit
     share_token: str
     is_shared: bool
+    is_template: bool
     created_at: datetime
     updated_at: datetime
 
@@ -86,6 +87,7 @@ class DataResponse(BaseModel):
 class CreateListIn(BaseModel):
     title: str = Field(min_length=1, max_length=100)
     description: str = Field(default="", max_length=500)
+    template_id: str | None = None
 
 
 class CreateItemIn(BaseModel):
@@ -103,3 +105,7 @@ class UpdateItemIn(CreateItemIn):
 
 class SetUnitIn(BaseModel):
     unit: Unit
+
+
+class SetTemplateIn(BaseModel):
+    is_template: bool


### PR DESCRIPTION
### Motivation

- Provide a template feature so users can save a packing list as a template and create new lists by cloning a template to speed up list creation.

### Description

- Add `is_template` boolean to `PackingList` and expose it in API response schemas so lists can be marked as templates.
- Allow `POST /api/v1/lists` to accept `template_id` and clone the template's items into the newly created list via a `_clone_template_items` helper.
- Add `PATCH /api/v1/lists/{list_id}/template` to toggle a list's template flag and a new `SetTemplateIn` schema and frontend API call (`setTemplate`).
- Update frontend list creation dialog to optionally select a template and the list detail page to toggle template status, plus adjust types and tests accordingly.

### Testing

- Ran backend API tests with `uv run pytest tests/api/test_api.py` and all tests passed (`9 passed`).
- Ran frontend unit tests with `cd frontend && npm run test -- --run` and the suite passed (`Test Files 3 passed`, `Tests 8 passed`).
- Verified code compiles with `python -m compileall src/ul_packing frontend/src` and captured an updated UI screenshot during a local dev run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f57f560483328990468fefaeff5e)