### PR TITLE
Add template packing list creation flow

### DIFF
--- a/frontend/src/components/list-create-form.tsx
+++ b/frontend/src/components/list-create-form.tsx
@@ -1,32 +1,48 @@
 import { useForm } from 'react-hook-form'
 
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
+import type { PackingList } from '@/lib/types'
 
 export type ListFormValue = {
   title: string
   description: string
+  template_list_id?: string
+  is_template: boolean
 }
 
 type Props = {
   isSubmitting: boolean
+  templateOptions: PackingList[]
   onSubmit: (values: ListFormValue) => Promise<void>
 }
 
-export function ListCreateForm({ isSubmitting, onSubmit }: Props) {
+export function ListCreateForm({ isSubmitting, templateOptions, onSubmit }: Props) {
   const {
     register,
     handleSubmit,
+    setValue,
+    watch,
     formState: { errors },
     reset,
   } = useForm<ListFormValue>({
-    defaultValues: { title: '', description: '' },
+    defaultValues: { title: '', description: '', template_list_id: undefined, is_template: false },
   })
 
+  const selectedTemplateId = watch('template_list_id')
+  const isTemplate = watch('is_template')
+
   const submit = async (values: ListFormValue) => {
-    await onSubmit({ title: values.title.trim(), description: values.description.trim() })
+    await onSubmit({
+      title: values.title.trim(),
+      description: values.description.trim(),
+      template_list_id: values.template_list_id || undefined,
+      is_template: values.is_template,
+    })
     reset()
   }
 
@@ -41,6 +57,24 @@ export function ListCreateForm({ isSubmitting, onSubmit }: Props) {
         <Label htmlFor="description">説明</Label>
         <Textarea id="description" {...register('description', { maxLength: 500 })} placeholder="任意メモ" />
         {errors.description ? <p className="text-sm text-destructive">説明が長すぎます。</p> : null}
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="template-list">テンプレートから作成（任意）</Label>
+        <Select value={selectedTemplateId ?? 'none'} onValueChange={(value) => setValue('template_list_id', value === 'none' ? undefined : value)}>
+          <SelectTrigger id="template-list">
+            <SelectValue placeholder="テンプレートを選択" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">指定なし</SelectItem>
+            {templateOptions.map((template) => (
+              <SelectItem key={template.id} value={template.id}>{template.title}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch id="is-template" checked={isTemplate} onCheckedChange={(checked) => setValue('is_template', checked)} />
+        <Label htmlFor="is-template">このリストをテンプレートとして保存</Label>
       </div>
       <Button type="submit" disabled={isSubmitting}>
         {isSubmitting ? '作成中...' : 'リストを作成'}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,6 +62,8 @@ const listPath = (listId: string, suffix = '') => `/api/v1/lists/${listId}${suff
 export type ListPayload = {
   title: string
   description: string
+  template_list_id?: string
+  is_template?: boolean
 }
 
 export type ItemPayload = {
@@ -75,6 +77,7 @@ export type ItemPayload = {
 
 export const api = {
   getLists: () => request<PackingList[]>('/api/v1/lists'),
+  getTemplates: () => request<PackingList[]>('/api/v1/lists/templates'),
   getGearItems: () => request<GearListItem[]>('/api/v1/gear-items'),
   createGearItem: (payload: ItemPayload) => requestWithBody<GearListItem>('/api/v1/gear-items', 'POST', payload),
   createList: (payload: ListPayload) => requestWithBody<PackingList>('/api/v1/lists', 'POST', payload),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -52,6 +52,7 @@ export type PackingList = {
   unit: Unit
   share_token: string
   is_shared: boolean
+  is_template?: boolean
   created_at: string
   updated_at: string
 }

--- a/frontend/src/pages/__tests__/lists-page.test.tsx
+++ b/frontend/src/pages/__tests__/lists-page.test.tsx
@@ -3,8 +3,8 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 
-import { ListsPage } from '@/pages/lists-page'
 import { api } from '@/lib/api'
+import { ListsPage } from '@/pages/lists-page'
 
 vi.mock('@/lib/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/api')>()
@@ -14,12 +14,14 @@ vi.mock('@/lib/api', async (importOriginal) => {
       ...actual.api,
       getLists: vi.fn(),
       createList: vi.fn(),
+      getTemplates: vi.fn(),
     },
   }
 })
 
 const mockedGetLists = vi.mocked(api.getLists)
 const mockedCreateList = vi.mocked(api.createList)
+const mockedGetTemplates = vi.mocked(api.getTemplates)
 
 const renderPage = () => {
   const queryClient = new QueryClient({
@@ -48,9 +50,11 @@ describe('ListsPage', () => {
       unit: 'g',
       share_token: '',
       is_shared: false,
+      is_template: false,
       created_at: '',
       updated_at: '',
     })
+    mockedGetTemplates.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -66,6 +70,7 @@ describe('ListsPage', () => {
         unit: 'g',
         share_token: '',
         is_shared: false,
+        is_template: false,
         created_at: '',
         updated_at: '',
       },

--- a/frontend/src/pages/lists-page.tsx
+++ b/frontend/src/pages/lists-page.tsx
@@ -29,6 +29,7 @@ export function ListsPage() {
   const [isCreateListOpen, setIsCreateListOpen] = useState(false)
 
   const listQuery = useQuery({ queryKey: ['lists'], queryFn: api.getLists })
+  const templateQuery = useQuery({ queryKey: ['list-templates'], queryFn: api.getTemplates })
   const createListMutation = useMutation({
     mutationFn: api.createList,
     onSuccess: async (list) => {
@@ -38,6 +39,8 @@ export function ListsPage() {
     },
     onError: (error) => toast.error(apiErrorMessage(error, 'リストの作成に失敗しました')),
   })
+  const packingLists = listQuery.data?.filter((list) => !list.is_template)
+
   return (
     <div className="grid">
       <Dialog open={isCreateListOpen} onOpenChange={setIsCreateListOpen}>
@@ -47,7 +50,7 @@ export function ListsPage() {
       <div>
         {listQuery.isLoading ? <p>読み込み中...</p> : null}
         {listQuery.isError ? <p className="text-destructive">リストの読み込みに失敗しました。</p> : null}
-        {listQuery.data?.length === 0 ? (
+        {packingLists?.length === 0 ? (
           <div className="grid justify-items-center gap-3 py-6 text-center">
             <p className="text-sm text-muted-foreground">
               まだパッキングリストがありません。最初のリストを作成しましょう。
@@ -57,7 +60,7 @@ export function ListsPage() {
             </Button>
           </div>
         ) : null}
-        {listQuery.data && listQuery.data.length > 0 ? (
+        {packingLists && packingLists.length > 0 ? (
           <Table className="[&_td]:py-3">
             <TableHeader>
               <TableRow>
@@ -73,7 +76,7 @@ export function ListsPage() {
                   </DialogTrigger>
                 </TableCell>
               </TableRow>
-              {listQuery.data.map((list) => (
+              {packingLists.map((list) => (
                 <TableRow
                   key={list.id}
                   tabIndex={0}
@@ -102,6 +105,7 @@ export function ListsPage() {
         </DialogHeader>
         <ListCreateForm
           isSubmitting={createListMutation.isPending}
+          templateOptions={templateQuery.data ?? []}
           onSubmit={async (values) => {
             await createListMutation.mutateAsync(values)
           }}

--- a/src/ul_packing/models.py
+++ b/src/ul_packing/models.py
@@ -42,6 +42,7 @@ class PackingList(Base):
     unit: Mapped[Unit] = mapped_column(Enum(Unit), default=Unit.G, nullable=False)
     share_token: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
     is_shared: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_template: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/ul_packing/routes_api.py
+++ b/src/ul_packing/routes_api.py
@@ -123,6 +123,28 @@ def _create_item_entity(list_id: str, payload: CreateItemIn, sort_order: int) ->
     return item
 
 
+def _clone_items_from_template(db: Session, source_list_id: str, destination_list_id: str) -> None:
+    template_items = db.execute(
+        select(GearItem)
+        .where(GearItem.list_id == source_list_id)
+        .order_by(GearItem.sort_order.asc(), GearItem.id.asc())
+    ).scalars().all()
+
+    for index, template_item in enumerate(template_items):
+        db.add(
+            GearItem(
+                list_id=destination_list_id,
+                name=template_item.name,
+                category=template_item.category,
+                weight_grams=template_item.weight_grams,
+                quantity=template_item.quantity,
+                kind=template_item.kind,
+                notes=template_item.notes,
+                sort_order=index,
+            )
+        )
+
+
 def _get_or_create_gear_inventory_list(db: Session) -> PackingList:
     inventory = db.execute(
         select(PackingList)
@@ -153,6 +175,16 @@ def get_lists(db: Session = Depends(get_db)):
     return {"data": [_to_list_data(packing_list, include_items=False) for packing_list in lists]}
 
 
+@router.get("/lists/templates")
+def get_templates(db: Session = Depends(get_db)):
+    templates = db.execute(
+        select(PackingList)
+        .where(PackingList.is_template.is_(True))
+        .order_by(PackingList.created_at.desc())
+    ).scalars().all()
+    return {"data": [_to_list_data(packing_list, include_items=False) for packing_list in templates]}
+
+
 @router.get("/gear-items")
 def get_gear_items(db: Session = Depends(get_db)):
     rows = db.execute(
@@ -171,12 +203,22 @@ def create_list(payload: CreateListIn, db: Session = Depends(get_db)):
     if not title:
         return _api_error(422, "validation_error", "Title is required")
 
+    template_list: PackingList | None = None
+    if payload.template_list_id:
+        template_list = _get_list_or_404(db, payload.template_list_id)
+
     packing_list = PackingList(
         title=title,
         description=payload.description.strip(),
         share_token=generate_share_token(),
+        is_template=payload.is_template,
     )
     db.add(packing_list)
+    db.flush()
+
+    if template_list:
+        _clone_items_from_template(db, source_list_id=template_list.id, destination_list_id=packing_list.id)
+
     db.commit()
     db.refresh(packing_list)
     return {"data": _to_list_data(packing_list, include_items=False)}

--- a/src/ul_packing/schemas_api.py
+++ b/src/ul_packing/schemas_api.py
@@ -61,6 +61,7 @@ class PackingListListItemOut(BaseModel):
     unit: Unit
     share_token: str
     is_shared: bool
+    is_template: bool
     created_at: datetime
     updated_at: datetime
 
@@ -86,10 +87,13 @@ class DataResponse(BaseModel):
 class CreateListIn(BaseModel):
     title: str = Field(min_length=1, max_length=100)
     description: str = Field(default="", max_length=500)
+    template_list_id: str | None = None
+    is_template: bool = False
 
 
-class UpdateListIn(CreateListIn):
-    pass
+class UpdateListIn(BaseModel):
+    title: str = Field(min_length=1, max_length=100)
+    description: str = Field(default="", max_length=500)
 
 
 class CreateItemIn(BaseModel):

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -217,3 +217,53 @@ def test_cors_preflight_for_spa_origin(client) -> None:
     )
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:4173"
+
+
+def test_create_list_from_template(client, session) -> None:
+    template = PackingList(title="Template", share_token=generate_share_token(), is_template=True)
+    session.add(template)
+    session.commit()
+
+    session.add(
+        GearItem(
+            list_id=template.id,
+            name="Shelter",
+            category="shelter",
+            weight_grams=700,
+            quantity=1,
+            kind="base",
+            notes="",
+            sort_order=0,
+        )
+    )
+    session.commit()
+
+    created = client.post(
+        "/api/v1/lists",
+        json={
+            "title": "Weekend",
+            "description": "from template",
+            "template_list_id": template.id,
+        },
+    )
+
+    assert created.status_code == 200
+    list_id = created.json()["data"]["id"]
+
+    detail = client.get(f"/api/v1/lists/{list_id}")
+    assert detail.status_code == 200
+    assert len(detail.json()["data"]["items"]) == 1
+    assert detail.json()["data"]["items"][0]["name"] == "Shelter"
+
+
+def test_get_templates_returns_template_lists_only(client, session) -> None:
+    session.add(PackingList(title="Normal", share_token=generate_share_token(), is_template=False))
+    session.add(PackingList(title="Template", share_token=generate_share_token(), is_template=True))
+    session.commit()
+
+    response = client.get("/api/v1/lists/templates")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["title"] == "Template"


### PR DESCRIPTION
### Motivation
- Provide a way to reuse packing configurations by allowing lists to be saved as templates and to create new lists from existing templates.
- Keep existing behavior for normal lists while exposing template-related metadata through the API and UI.

### Description
- Add `is_template: bool` to the `PackingList` model and expose `is_template` in the API schema as well as `template_list_id` and `is_template` in the `CreateListIn` payload.
- Implement a templates listing endpoint `GET /api/v1/lists/templates`, a helper to clone items from a template (`_clone_items_from_template`), and extend `POST /api/v1/lists` to optionally clone template items and to set the `is_template` flag when creating a list.
- Frontend: extend API client (`getTemplates`, `ListPayload`), add template selection and "save as template" toggle to the list creation form, and fetch templates from `ListsPage` while hiding template lists from the main packing list table.
- Tests: add API tests for creating a list from a template and for the templates listing, and update frontend unit tests to mock the new templates API.

### Testing
- Ran `uv run pytest tests/api/test_api.py` and all backend API tests passed (`9 passed`).
- Ran `cd frontend && npm run test -- src/pages/__tests__/lists-page.test.tsx` and the modified frontend unit tests passed (`3 passed`).
- E2E (`npx playwright test`) and full frontend test-suite were not executed to limit scope to the changed areas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d20faf6608332b0624fd562712f3c)